### PR TITLE
added tests for full house

### DIFF
--- a/test_yatzy.rb
+++ b/test_yatzy.rb
@@ -91,6 +91,8 @@ class YatzyTest < Test::Unit::TestCase
   def test_fullHouse()
     assert 18 == Yatzy.fullHouse(6,2,2,2,6)
     assert 0 == Yatzy.fullHouse(2,3,4,5,6)
+    assert 0 == Yatzy.fullHouse(3,3,3,1,5)
+    assert 0 == Yatzy.fullHouse(4,4,4,4,4)
   end
 end
 


### PR DESCRIPTION
Interviewees often have logic errors in full house that are not being caught by tests.
Often their solution tests for two_of_a_kind and three_of_a_kind and assume that's a full house, without realizing that a three_of_a_kind e.g. (3,3,3,1,5) would pass those two conditions.
